### PR TITLE
all: rename package to github.com/charlievieth/go-sqlite3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 go-sqlite3
 ==========
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/mattn/go-sqlite3.svg)](https://pkg.go.dev/github.com/mattn/go-sqlite3)
-[![GitHub Actions](https://github.com/mattn/go-sqlite3/workflows/Go/badge.svg)](https://github.com/mattn/go-sqlite3/actions?query=workflow%3AGo)
+[![Go Reference](https://pkg.go.dev/badge/github.com/charlievieth/go-sqlite3.svg)](https://pkg.go.dev/github.com/charlievieth/go-sqlite3)
+[![GitHub Actions](https://github.com/charlievieth/go-sqlite3/workflows/Go/badge.svg)](https://github.com/charlievieth/go-sqlite3/actions?query=workflow%3AGo)
 [![Financial Contributors on Open Collective](https://opencollective.com/mattn-go-sqlite3/all/badge.svg?label=financial+contributors)](https://opencollective.com/mattn-go-sqlite3) 
 [![codecov](https://codecov.io/gh/mattn/go-sqlite3/branch/master/graph/badge.svg)](https://codecov.io/gh/mattn/go-sqlite3)
-[![Go Report Card](https://goreportcard.com/badge/github.com/mattn/go-sqlite3)](https://goreportcard.com/report/github.com/mattn/go-sqlite3)
+[![Go Report Card](https://goreportcard.com/badge/github.com/charlievieth/go-sqlite3)](https://goreportcard.com/report/github.com/charlievieth/go-sqlite3)
 
 Latest stable version is v1.14 or later, not v2.
 
@@ -66,17 +66,17 @@ This package follows the official [Golang Release Policy](https://golang.org/doc
 
 This package can be installed with the `go get` command:
 
-    go get github.com/mattn/go-sqlite3
+    go get github.com/charlievieth/go-sqlite3
 
 _go-sqlite3_ is *cgo* package.
 If you want to build your app using go-sqlite3, you need gcc.
-However, after you have built and installed _go-sqlite3_ with `go install github.com/mattn/go-sqlite3` (which requires gcc), you can build your app without relying on gcc in future.
+However, after you have built and installed _go-sqlite3_ with `go install github.com/charlievieth/go-sqlite3` (which requires gcc), you can build your app without relying on gcc in future.
 
 ***Important: because this is a `CGO` enabled package, you are required to set the environment variable `CGO_ENABLED=1` and have a `gcc` compiler present within your path.***
 
 # API Reference
 
-API documentation can be found [here](http://godoc.org/github.com/mattn/go-sqlite3).
+API documentation can be found [here](http://godoc.org/github.com/charlievieth/go-sqlite3).
 
 Examples can be found under the [examples](./_example) directory.
 
@@ -180,7 +180,7 @@ go build -tags "icu json1 fts5 secure_delete"
 | Secure Delete (FAST) | sqlite_secure_delete_fast | For more information see [PRAGMA secure_delete](https://www.sqlite.org/pragma.html#pragma_secure_delete) |
 | Tracing / Debug | sqlite_trace | Activate trace functions |
 | User Authentication | sqlite_userauth | SQLite User Authentication see [User Authentication](#user-authentication) for more information. |
-| Virtual Tables | sqlite_vtable | SQLite Virtual Tables see [SQLite Official VTABLE Documentation](https://www.sqlite.org/vtab.html) for more information, and a [full example here](https://github.com/mattn/go-sqlite3/tree/master/_example/vtable) |
+| Virtual Tables | sqlite_vtable | SQLite Virtual Tables see [SQLite Official VTABLE Documentation](https://www.sqlite.org/vtab.html) for more information, and a [full example here](https://github.com/charlievieth/go-sqlite3/tree/master/_example/vtable) |
 
 # Compilation
 
@@ -344,14 +344,14 @@ For example the TDM-GCC Toolchain can be found [here](https://jmeubank.github.io
     > Probably, you are using go 1.0, go1.0 has a problem when it comes to compiling/linking on windows 64bit.
     > See: [#27](https://github.com/mattn/go-sqlite3/issues/27)
 
-- `go get github.com/mattn/go-sqlite3` throws compilation error.
+- `go get github.com/charlievieth/go-sqlite3` throws compilation error.
 
     `gcc` throws: `internal compiler error`
 
     Remove the download repository from your disk and try re-install with:
 
     ```bash
-    go install github.com/mattn/go-sqlite3
+    go install github.com/charlievieth/go-sqlite3
     ```
 
 # User Authentication
@@ -560,31 +560,14 @@ For an example, see [dinedal/go-sqlite3-extension-functions](https://github.com/
 
 ### Code Contributors
 
-This project exists thanks to all the people who [[contribute](CONTRIBUTING.md)].
-<a href="https://github.com/mattn/go-sqlite3/graphs/contributors"><img src="https://opencollective.com/mattn-go-sqlite3/contributors.svg?width=890&button=false" /></a>
+This project is a fork of mattn/go-sqlite3 and is only possible thanks to the
+work of @mattn and other contributors. A full list of the original contributors
+can be found [here](https://github.com/mattn/go-sqlite3/?tab=readme-ov-file#contributors).
 
 ### Financial Contributors
 
-Become a financial contributor and help us sustain our community. [[Contribute here](https://opencollective.com/mattn-go-sqlite3/contribute)].
-
-#### Individuals
-
-<a href="https://opencollective.com/mattn-go-sqlite3"><img src="https://opencollective.com/mattn-go-sqlite3/individuals.svg?width=890"></a>
-
-#### Organizations
-
-Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/mattn-go-sqlite3/contribute)]
-
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/0/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/0/avatar.svg"></a>
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/1/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/1/avatar.svg"></a>
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/2/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/2/avatar.svg"></a>
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/3/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/3/avatar.svg"></a>
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/4/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/4/avatar.svg"></a>
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/5/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/5/avatar.svg"></a>
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/6/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/6/avatar.svg"></a>
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/7/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/7/avatar.svg"></a>
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/8/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/8/avatar.svg"></a>
-<a href="https://opencollective.com/mattn-go-sqlite3/organization/9/website"><img src="https://opencollective.com/mattn-go-sqlite3/organization/9/avatar.svg"></a>
+This project is a fork of mattn/go-sqlite3. A list of it's financial contributors
+can be found [here](https://github.com/mattn/go-sqlite3/?tab=readme-ov-file#financial-contributors).
 
 # License
 
@@ -601,3 +584,5 @@ In this repository, those files are an amalgamation of code that was copied from
 Yasuhiro Matsumoto (a.k.a mattn)
 
 G.J.R. Timmer
+
+Charlie Vieth (fork maintainer)

--- a/_example/custom_driver_name/Makefile
+++ b/_example/custom_driver_name/Makefile
@@ -6,7 +6,7 @@ endif
 all : $(TARGET)
 
 $(TARGET) : main.go
-	go build -ldflags="-X 'github.com/mattn/go-sqlite3.driverName=my-sqlite3'"
+	go build -ldflags="-X 'github.com/charlievieth/go-sqlite3.driverName=my-sqlite3'"
 
 clean :
 	rm -f $(TARGET)

--- a/_example/custom_driver_name/main.go
+++ b/_example/custom_driver_name/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"database/sql"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/charlievieth/go-sqlite3"
 )
 
 func main() {

--- a/_example/custom_func/main.go
+++ b/_example/custom_func/main.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"math/rand"
 
-	sqlite "github.com/mattn/go-sqlite3"
+	sqlite "github.com/charlievieth/go-sqlite3"
 )
 
 // Computes x^y

--- a/_example/fuzz/fuzz_openexec.go
+++ b/_example/fuzz/fuzz_openexec.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"io/ioutil"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/charlievieth/go-sqlite3"
 )
 
 func FuzzOpenExec(data []byte) int {

--- a/_example/hook/hook.go
+++ b/_example/hook/hook.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/mattn/go-sqlite3"
+	"github.com/charlievieth/go-sqlite3"
 )
 
 func main() {

--- a/_example/json/json.go
+++ b/_example/json/json.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/charlievieth/go-sqlite3"
 	"log"
 	"os"
 )

--- a/_example/limit/limit.go
+++ b/_example/limit/limit.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mattn/go-sqlite3"
+	"github.com/charlievieth/go-sqlite3"
 )
 
 func createBulkInsertQuery(n int, start int) (query string, args []any) {

--- a/_example/mod_regexp/extension.go
+++ b/_example/mod_regexp/extension.go
@@ -3,7 +3,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	"github.com/mattn/go-sqlite3"
+	"github.com/charlievieth/go-sqlite3"
 	"log"
 )
 

--- a/_example/mod_vtable/extension.go
+++ b/_example/mod_vtable/extension.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mattn/go-sqlite3"
+	"github.com/charlievieth/go-sqlite3"
 )
 
 func main() {

--- a/_example/simple/Dockerfile
+++ b/_example/simple/Dockerfile
@@ -28,7 +28,7 @@ COPY . /workspace/
 RUN \
     cd _example/simple && \
     go mod init github.com/mattn/sample && \
-    go mod edit -replace=github.com/mattn/go-sqlite3=../.. && \
+    go mod edit -replace=github.com/charlievieth/go-sqlite3=../.. && \
     go mod tidy && \
     go install -ldflags='-s -w -extldflags "-static"' ./simple.go
 

--- a/_example/simple/simple.go
+++ b/_example/simple/simple.go
@@ -3,7 +3,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/charlievieth/go-sqlite3"
 	"log"
 	"os"
 )

--- a/_example/trace/main.go
+++ b/_example/trace/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	sqlite3 "github.com/mattn/go-sqlite3"
+	sqlite3 "github.com/charlievieth/go-sqlite3"
 )
 
 func traceCallback(info sqlite3.TraceInfo) int {

--- a/_example/vtable/main.go
+++ b/_example/vtable/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mattn/go-sqlite3"
+	"github.com/charlievieth/go-sqlite3"
 )
 
 func main() {

--- a/_example/vtable/vtable.go
+++ b/_example/vtable/vtable.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/mattn/go-sqlite3"
+	"github.com/charlievieth/go-sqlite3"
 )
 
 type githubRepo struct {

--- a/_example/vtable_eponymous_only/main.go
+++ b/_example/vtable_eponymous_only/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mattn/go-sqlite3"
+	"github.com/charlievieth/go-sqlite3"
 )
 
 func main() {

--- a/_example/vtable_eponymous_only/vtable.go
+++ b/_example/vtable_eponymous_only/vtable.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/mattn/go-sqlite3"
+	"github.com/charlievieth/go-sqlite3"
 )
 
 type seriesModule struct{}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
-module github.com/mattn/go-sqlite3
+module github.com/charlievieth/go-sqlite3
 
 go 1.19
 
-retract (
- [v2.0.0+incompatible, v2.0.6+incompatible] // Accidental; no major changes or features.
-)
+retract [v2.0.0+incompatible, v2.0.6+incompatible] // Accidental; no major changes or features.


### PR DESCRIPTION
This project is a hard'ish fork of github.com/mattn/go-sqlite3 that will not always be compatible with the original. Therefore I'm renaming it to avoid confusion.

Regarding incompatibilities, the first is that mattn/go-sqlite3 allows for the SQL passed to Query to contain multiple statements, but will only execute the last one - this package will return an error if Query is passed multiple SQL statements. The second incompatibility is that this library will eventually remove the rarely used RegisterAggregator since it uses reflect.MethodByName which disables dead code removal. The goal is to keep the number of incompatibilities to minimum, unless justified by correctness or performance reasons.

The overall goal of this package is to be more correct and performant than mattn/go-sqlite3 while not being constrained by backwards compatibility (apart from removing RegisterAggregator this package should only introduce breaking changes to code that is already incorrect).