### PR TITLE
reduce allocations when binding string/time args

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -2182,26 +2182,90 @@ func (s *SQLiteStmt) NumInput() int {
 
 var placeHolder = []byte{0}
 
+func hasNamedArgs(args []driver.NamedValue) bool {
+	for _, v := range args {
+		if v.Name != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *SQLiteStmt) bind(args []driver.NamedValue) error {
 	rv := C.sqlite3_reset(s.s)
 	if rv != C.SQLITE_ROW && rv != C.SQLITE_OK && rv != C.SQLITE_DONE {
 		return s.c.lastError()
 	}
 
+	if hasNamedArgs(args) {
+		return s.bindIndices(args)
+	}
+
+	for _, arg := range args {
+		n := C.int(arg.Ordinal)
+		switch v := arg.Value.(type) {
+		case nil:
+			rv = C.sqlite3_bind_null(s.s, n)
+		case string:
+			p := stringData(v)
+			rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(p)), C.int(len(v)))
+		case int64:
+			rv = C.sqlite3_bind_int64(s.s, n, C.sqlite3_int64(v))
+		case bool:
+			val := 0
+			if v {
+				val = 1
+			}
+			rv = C.sqlite3_bind_int(s.s, n, C.int(val))
+		case float64:
+			rv = C.sqlite3_bind_double(s.s, n, C.double(v))
+		case []byte:
+			if v == nil {
+				rv = C.sqlite3_bind_null(s.s, n)
+			} else {
+				ln := len(v)
+				if ln == 0 {
+					v = placeHolder
+				}
+				rv = C._sqlite3_bind_blob(s.s, n, unsafe.Pointer(&v[0]), C.int(ln))
+			}
+		case time.Time:
+			ts := v.Format(SQLiteTimestampFormats[0])
+			p := stringData(ts)
+			rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(p)), C.int(len(ts)))
+		}
+		if rv != C.SQLITE_OK {
+			return s.c.lastError()
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteStmt) bindIndices(args []driver.NamedValue) error {
+	// Find the longest named parameter name.
+	n := 0
+	for _, v := range args {
+		if m := len(v.Name); m > n {
+			n = m
+		}
+	}
+	buf := make([]byte, 0, n+2) // +2 for placeholder and null terminator
+
 	bindIndices := make([][3]int, len(args))
-	prefixes := []string{":", "@", "$"}
 	for i, v := range args {
 		bindIndices[i][0] = args[i].Ordinal
 		if v.Name != "" {
-			for j := range prefixes {
-				cname := C.CString(prefixes[j] + v.Name)
-				bindIndices[i][j] = int(C.sqlite3_bind_parameter_index(s.s, cname))
-				C.free(unsafe.Pointer(cname))
+			for j, c := range []byte{':', '@', '$'} {
+				buf = append(buf[:0], c)
+				buf = append(buf, v.Name...)
+				buf = append(buf, 0)
+				bindIndices[i][j] = int(C.sqlite3_bind_parameter_index(s.s, (*C.char)(unsafe.Pointer(&buf[0]))))
 			}
 			args[i].Ordinal = bindIndices[i][0]
 		}
 	}
 
+	var rv C.int
 	for i, arg := range args {
 		for j := range bindIndices[i] {
 			if bindIndices[i][j] == 0 {
@@ -2212,20 +2276,16 @@ func (s *SQLiteStmt) bind(args []driver.NamedValue) error {
 			case nil:
 				rv = C.sqlite3_bind_null(s.s, n)
 			case string:
-				if len(v) == 0 {
-					rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&placeHolder[0])), C.int(0))
-				} else {
-					b := []byte(v)
-					rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))
-				}
+				p := stringData(v)
+				rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(p)), C.int(len(v)))
 			case int64:
 				rv = C.sqlite3_bind_int64(s.s, n, C.sqlite3_int64(v))
 			case bool:
+				val := 0
 				if v {
-					rv = C.sqlite3_bind_int(s.s, n, 1)
-				} else {
-					rv = C.sqlite3_bind_int(s.s, n, 0)
+					val = 1
 				}
+				rv = C.sqlite3_bind_int(s.s, n, C.int(val))
 			case float64:
 				rv = C.sqlite3_bind_double(s.s, n, C.double(v))
 			case []byte:
@@ -2239,8 +2299,9 @@ func (s *SQLiteStmt) bind(args []driver.NamedValue) error {
 					rv = C._sqlite3_bind_blob(s.s, n, unsafe.Pointer(&v[0]), C.int(ln))
 				}
 			case time.Time:
-				b := []byte(v.Format(SQLiteTimestampFormats[0]))
-				rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))
+				ts := v.Format(SQLiteTimestampFormats[0])
+				p := stringData(ts)
+				rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(p)), C.int(len(ts)))
 			}
 			if rv != C.SQLITE_OK {
 				return s.c.lastError()


### PR DESCRIPTION
This commit reduces the number of allocations required to bind args by eliminating string to byte slice conversions for string and time.Time types and by only checking for bind parameters if any of the driver.NamedValue args are named.

```
goos: darwin
goarch: arm64
pkg: github.com/charlievieth/go-sqlite3
cpu: Apple M4 Pro
                                          │   x1.txt    │               x2.txt               │
                                          │   sec/op    │   sec/op     vs base               │
Suite/BenchmarkExec/Params-14               720.8n ± 1%   675.1n ± 1%  -6.33% (p=0.000 n=10)
Suite/BenchmarkExec/NoParams-14             493.0n ± 1%   467.5n ± 1%  -5.18% (p=0.000 n=10)
Suite/BenchmarkExecContext/Params-14        1.601µ ± 4%   1.538µ ± 1%  -3.97% (p=0.000 n=10)
Suite/BenchmarkExecContext/NoParams-14      1.416µ ± 1%   1.417µ ± 2%       ~ (p=0.566 n=10)
Suite/BenchmarkExecStep-14                  421.0µ ± 1%   415.1µ ± 1%  -1.39% (p=0.004 n=10)
Suite/BenchmarkExecContextStep-14           421.6µ ± 1%   415.7µ ± 1%  -1.41% (p=0.009 n=10)
Suite/BenchmarkExecTx-14                    1.537µ ± 1%   1.535µ ± 3%       ~ (p=0.342 n=10)
Suite/BenchmarkQuery-14                     1.837µ ± 1%   1.826µ ± 1%       ~ (p=0.093 n=10)
Suite/BenchmarkQuerySimple-14               1.127µ ± 1%   1.115µ ± 0%  -1.15% (p=0.000 n=10)
Suite/BenchmarkQueryContext/Background-14   2.349µ ± 1%   2.323µ ± 1%       ~ (p=0.052 n=10)
Suite/BenchmarkQueryContext/WithCancel-14   8.796µ ± 5%   8.624µ ± 5%       ~ (p=0.912 n=10)
Suite/BenchmarkParams-14                    2.043µ ± 2%   1.989µ ± 1%  -2.64% (p=0.000 n=10)
Suite/BenchmarkStmt-14                      1.383µ ± 1%   1.368µ ± 0%  -1.12% (p=0.000 n=10)
Suite/BenchmarkRows-14                      57.55µ ± 1%   56.86µ ± 1%       ~ (p=0.052 n=10)
Suite/BenchmarkStmtRows-14                  56.57µ ± 1%   56.89µ ± 2%       ~ (p=0.739 n=10)
Suite/BenchmarkStmt10Cols-14                4.230µ ± 1%   4.222µ ± 1%       ~ (p=0.109 n=10)
geomean                                     5.281µ        5.189µ       -1.75%

                                          │    x1.txt    │                 x2.txt                 │
                                          │     B/op     │     B/op      vs base                  │
Suite/BenchmarkExec/Params-14                 240.0 ± 0%     216.0 ± 0%  -10.00% (p=0.000 n=10)
Suite/BenchmarkExec/NoParams-14               64.00 ± 0%     64.00 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkExecContext/Params-14          399.0 ± 0%     375.0 ± 0%   -6.02% (p=0.000 n=10)
Suite/BenchmarkExecContext/NoParams-14        208.0 ± 0%     208.0 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkExecStep-14                    64.00 ± 0%     64.00 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkExecContextStep-14             208.0 ± 0%     208.0 ± 0%        ~ (p=0.737 n=10)
Suite/BenchmarkExecTx-14                      520.0 ± 0%     520.0 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkQuery-14                       656.0 ± 0%     656.0 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkQuerySimple-14                 456.0 ± 0%     456.0 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkQueryContext/Background-14     396.0 ± 0%     396.0 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkQueryContext/WithCancel-14   1.273Ki ± 0%   1.273Ki ± 0%        ~ (p=0.211 n=10)
Suite/BenchmarkParams-14                      904.0 ± 0%     800.0 ± 0%  -11.50% (p=0.000 n=10)
Suite/BenchmarkStmt-14                        888.0 ± 0%     784.0 ± 0%  -11.71% (p=0.000 n=10)
Suite/BenchmarkRows-14                      9.188Ki ± 0%   9.188Ki ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkStmtRows-14                  9.180Ki ± 0%   9.180Ki ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkStmt10Cols-14                  712.0 ± 0%     712.0 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                       549.4          535.4        -2.56%
¹ all samples are equal

                                          │   x1.txt   │                x2.txt                │
                                          │ allocs/op  │ allocs/op   vs base                  │
Suite/BenchmarkExec/Params-14               9.000 ± 0%   8.000 ± 0%  -11.11% (p=0.000 n=10)
Suite/BenchmarkExec/NoParams-14             4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkExecContext/Params-14        11.00 ± 0%   10.00 ± 0%   -9.09% (p=0.000 n=10)
Suite/BenchmarkExecContext/NoParams-14      6.000 ± 0%   6.000 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkExecStep-14                  4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkExecContextStep-14           6.000 ± 0%   6.000 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkExecTx-14                    18.00 ± 0%   18.00 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkQuery-14                     22.00 ± 0%   22.00 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkQuerySimple-14               13.00 ± 0%   13.00 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkQueryContext/Background-14   10.00 ± 0%   10.00 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkQueryContext/WithCancel-14   26.00 ± 0%   26.00 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkParams-14                    25.00 ± 0%   23.00 ± 0%   -8.00% (p=0.000 n=10)
Suite/BenchmarkStmt-14                      25.00 ± 0%   23.00 ± 0%   -8.00% (p=0.000 n=10)
Suite/BenchmarkRows-14                      518.0 ± 0%   518.0 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkStmtRows-14                  518.0 ± 0%   518.0 ± 0%        ~ (p=1.000 n=10) ¹
Suite/BenchmarkStmt10Cols-14                19.00 ± 0%   19.00 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                     18.80        18.36        -2.35%
¹ all samples are equal
```