### PR TITLE
sqlite3: don't copy query string in SQLiteConn.Prepare

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -549,7 +549,6 @@ type SQLiteStmt struct {
 	mu     sync.Mutex
 	c      *SQLiteConn
 	s      *C.sqlite3_stmt
-	t      string
 	closed bool
 	cls    bool
 }
@@ -2064,19 +2063,13 @@ func (c *SQLiteConn) Prepare(query string) (driver.Stmt, error) {
 }
 
 func (c *SQLiteConn) prepare(ctx context.Context, query string) (driver.Stmt, error) {
-	pquery := C.CString(query)
-	defer C.free(unsafe.Pointer(pquery))
+	p := stringData(query)
 	var s *C.sqlite3_stmt
-	var tail *C.char
-	rv := C._sqlite3_prepare_v2_internal(c.db, pquery, C.int(-1), &s, &tail)
+	rv := C._sqlite3_prepare_v2_internal(c.db, (*C.char)(unsafe.Pointer(p)), C.int(len(query)), &s, nil)
 	if rv != C.SQLITE_OK {
 		return nil, c.lastError()
 	}
-	var t string
-	if tail != nil && *tail != '\000' {
-		t = strings.TrimSpace(C.GoString(tail))
-	}
-	ss := &SQLiteStmt{c: c, s: s, t: t}
+	ss := &SQLiteStmt{c: c, s: s}
 	runtime.SetFinalizer(ss, (*SQLiteStmt).Close)
 	return ss, nil
 }


### PR DESCRIPTION
Change prepare to use a pointer to the Go string instead of copying it to a C string. This saves an alloc.