### PR TITLE
Use a reference to C memory instead of a copy for BLOBs

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -50,6 +50,9 @@ jobs:
       - name: 'Tags: vacuum'
         run: go test -v -tags "sqlite_vacuum_full"
 
+      - name: 'Tags: copy bytes'
+        run: go test -v -tags "sqlite_copy_bytes"
+
       # - name: Upload coverage to Codecov
       #   uses: codecov/codecov-action@v1
       #   with:

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ go build -tags "icu json1 fts5 secure_delete"
 | Tracing / Debug | sqlite_trace | Activate trace functions |
 | User Authentication | sqlite_userauth | SQLite User Authentication see [User Authentication](#user-authentication) for more information. |
 | Virtual Tables | sqlite_vtable | SQLite Virtual Tables see [SQLite Official VTABLE Documentation](https://www.sqlite.org/vtab.html) for more information, and a [full example here](https://github.com/charlievieth/go-sqlite3/tree/master/_example/vtable) |
+| Legacy Blob Assignment | sqlite_copy_bytes | Assign a copy of the BLOB into a []byte slice destination when scanning rows instead of a reference to the C memory. This was the previous behavior and should only be necessary for applications that use this library directly since the [database/sql](https://pkg.go.dev/database/sql) package creates a copy of the slice, unless the destination is [sql.RawBytes](https://pkg.go.dev/database/sql#RawBytes) |
+
 
 # Compilation
 

--- a/sqlite3_opt_blob_copy.go
+++ b/sqlite3_opt_blob_copy.go
@@ -1,0 +1,8 @@
+//go:build sqlite_copy_bytes
+// +build sqlite_copy_bytes
+
+package sqlite3
+
+// Create a copy of the BLOB's C memory with C.GoBytes when assigning to a
+// destination in Scan. This is the prior behavior of mattn/go-sqlite3.
+const copyBytesOnAssignment = true

--- a/sqlite3_opt_blob_no_copy.go
+++ b/sqlite3_opt_blob_no_copy.go
@@ -1,0 +1,8 @@
+//go:build !sqlite_copy_bytes
+// +build !sqlite_copy_bytes
+
+package sqlite3
+
+// Assign a reference to sqlite3's C memory when assigning a BLOB to a byte
+// slice. This is safe because the database/sql package creates a copy.
+const copyBytesOnAssignment = false


### PR DESCRIPTION
This changes Scan to assign a reference to a BLOBs C memory instead of creating a copy and is safe because the database/sql package creates a copy unless the destination is a sql.RawBytes. Basically, this savs a useless alloc.

This change may break programs that use *sqlite3.SQLiteRows directly instead of through the sql package.

The `sqlite_copy_bytes` build tag was added to disable this behavior and revert to the prior behavior of copying the byte slice.

```
goos: darwin
goarch: arm64
pkg: github.com/charlievieth/go-sqlite3
cpu: Apple M4 Pro
                               │   x1.txt    │               x2.txt                │
                               │   sec/op    │   sec/op     vs base                │
Suite/BenchmarkScanRawBytes-14   3.084µ ± 6%   2.658µ ± 0%  -13.81% (p=0.000 n=10)

                               │   x1.txt    │               x2.txt               │
                               │    B/op     │    B/op     vs base                │
Suite/BenchmarkScanRawBytes-14   8784.0 ± 0%   592.0 ± 0%  -93.26% (p=0.000 n=10)

                               │   x1.txt   │               x2.txt               │
                               │ allocs/op  │ allocs/op   vs base                │
Suite/BenchmarkScanRawBytes-14   26.00 ± 0%   18.00 ± 0%  -30.77% (p=0.000 n=10)
```