### PR TITLE
remove superfluous use of runtime.SetFinalizer on SQLiteRows

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -550,7 +550,7 @@ type SQLiteStmt struct {
 	c      *SQLiteConn
 	s      *C.sqlite3_stmt
 	closed bool
-	cls    bool
+	cls    bool // True if the statement was created by SQLiteConn.Query
 }
 
 // SQLiteResult implements sql.Result.
@@ -580,14 +580,14 @@ func (c columnType) dataType() int {
 // SQLiteRows implements driver.Rows.
 type SQLiteRows struct {
 	s        *SQLiteStmt
-	nc       int
+	nc       int32 // Number of columns
+	cls      bool  // True if we need close the statement in Close
 	cols     []string
 	decltype []string
 	coltype  []columnType
-	cls      bool
-	closed   bool
 	ctx      context.Context // no better alternative to pass context into Next() method
 	resultCh chan error
+	closemu  sync.Mutex
 }
 
 type functionInfo struct {
@@ -1175,7 +1175,7 @@ func (c *SQLiteConn) Query(query string, args []driver.Value) (driver.Rows, erro
 	return c.query(context.Background(), query, list)
 }
 
-var closedRows = &SQLiteRows{s: &SQLiteStmt{closed: true}, closed: true}
+var closedRows = &SQLiteRows{s: &SQLiteStmt{closed: true}}
 
 func (c *SQLiteConn) query(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	s := SQLiteStmt{c: c, cls: true}
@@ -2323,14 +2323,12 @@ func (s *SQLiteStmt) query(ctx context.Context, args []driver.NamedValue) (drive
 
 	rows := &SQLiteRows{
 		s:        s,
-		nc:       int(C.sqlite3_column_count(s.s)),
+		nc:       int32(C.sqlite3_column_count(s.s)),
+		cls:      s.cls,
 		cols:     nil,
 		decltype: nil,
-		cls:      s.cls,
-		closed:   false,
 		ctx:      ctx,
 	}
-	runtime.SetFinalizer(rows, (*SQLiteRows).Close)
 
 	return rows, nil
 }
@@ -2427,24 +2425,28 @@ func (s *SQLiteStmt) Readonly() bool {
 
 // Close the rows.
 func (rc *SQLiteRows) Close() error {
-	rc.s.mu.Lock()
-	if rc.s.closed || rc.closed {
-		rc.s.mu.Unlock()
+	rc.closemu.Lock()
+	defer rc.closemu.Unlock()
+	s := rc.s
+	if s == nil {
 		return nil
 	}
-	rc.closed = true
+	rc.s = nil // remove reference to SQLiteStmt
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
 	if rc.cls {
-		rc.s.mu.Unlock()
-		return rc.s.Close()
+		s.mu.Unlock()
+		return s.Close()
 	}
-	rv := C.sqlite3_reset(rc.s.s)
+	rv := C.sqlite3_reset(s.s)
 	if rv != C.SQLITE_OK {
-		rc.s.mu.Unlock()
-		return rc.s.c.lastError()
+		s.mu.Unlock()
+		return s.c.lastError()
 	}
-	rc.s.mu.Unlock()
-	rc.s = nil
-	runtime.SetFinalizer(rc, nil)
+	s.mu.Unlock()
 	return nil
 }
 
@@ -2452,9 +2454,9 @@ func (rc *SQLiteRows) Close() error {
 func (rc *SQLiteRows) Columns() []string {
 	rc.s.mu.Lock()
 	defer rc.s.mu.Unlock()
-	if rc.s.s != nil && rc.nc != len(rc.cols) {
+	if rc.s.s != nil && int(rc.nc) != len(rc.cols) {
 		rc.cols = make([]string, rc.nc)
-		for i := 0; i < rc.nc; i++ {
+		for i := 0; i < int(rc.nc); i++ {
 			rc.cols[i] = C.GoString(C.sqlite3_column_name(rc.s.s, C.int(i)))
 		}
 	}
@@ -2467,7 +2469,7 @@ func (rc *SQLiteRows) DeclTypes() []string {
 	defer rc.s.mu.Unlock()
 	if rc.s.s != nil && rc.decltype == nil {
 		rc.decltype = make([]string, rc.nc)
-		for i := 0; i < rc.nc; i++ {
+		for i := 0; i < int(rc.nc); i++ {
 			rc.decltype[i] = strings.ToLower(C.GoString(C.sqlite3_column_decltype(rc.s.s, C.int(i))))
 		}
 	}


### PR DESCRIPTION
The commit removes the use of runtime.SetFinalizer to finalize SQLiteRows since only serves to close the associated SQLiteStmt which already has a registered finalizer.

It also fixes a race and potential panic in SQLiteRows.Close around the SQLiteRows.s field (*SQLiteStmt) which is accessed without a mutex being held, but modified with it held (null'd out). Further the mutex we are holding is that of the SQLiteStmt so a subsequent call to Close will cause a panic sine it'll attempt to dereference a nil field. The fix here is to add a mutex for closing to SQLiteRows.

Since we now also set the s field to nil when closing this commit removes the "closed" field (since checking if s is nil is the same) and also changes the type of "nc" (number of columns) to an int32 so that we can pack the nc and cls fields, and add the close mutex without making the struct any bigger.

```
goos: darwin
goarch: arm64
pkg: github.com/charlievieth/go-sqlite3
cpu: Apple M4 Pro
                                          │   x1.txt    │               x4.txt                │
                                          │   sec/op    │   sec/op     vs base                │
Suite/BenchmarkQuery-14                     1.968µ ± 3%   1.821µ ± 1%   -7.52% (p=0.000 n=10)
Suite/BenchmarkQuerySimple-14               1.207µ ± 2%   1.040µ ± 1%  -13.84% (p=0.000 n=10)
Suite/BenchmarkQueryContext/Background-14   2.400µ ± 1%   2.320µ ± 0%   -3.31% (p=0.000 n=10)
Suite/BenchmarkQueryContext/WithCancel-14   8.847µ ± 5%   8.512µ ± 4%   -3.79% (p=0.007 n=10)
Suite/BenchmarkParams-14                    2.131µ ± 2%   1.967µ ± 1%   -7.70% (p=0.000 n=10)
Suite/BenchmarkStmt-14                      1.444µ ± 1%   1.359µ ± 1%   -5.89% (p=0.000 n=10)
Suite/BenchmarkRows-14                      61.57µ ± 1%   60.24µ ± 1%   -2.16% (p=0.000 n=10)
Suite/BenchmarkStmtRows-14                  60.15µ ± 1%   59.08µ ± 1%   -1.78% (p=0.000 n=10)
Suite/BenchmarkStmt10Cols-14                4.475µ ± 1%   4.353µ ± 0%   -2.74% (p=0.000 n=10)
Suite/BenchmarkScanRawBytes-14              2.537µ ± 1%   2.417µ ± 0%   -4.75% (p=0.000 n=10)
Suite/BenchmarkQueryParallel-14             960.9n ± 1%   420.8n ± 2%  -56.21% (p=0.000 n=10)
geomean                                     4.149µ        3.659µ       -11.81%
```