### PR TITLE
reduce the number of allocations required by Open

### DIFF
--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -3104,12 +3104,10 @@ func benchmarkQueryParallel(b *testing.B) {
 }
 
 func benchmarkOpen(b *testing.B) {
+	var d SQLiteDriver
 	for i := 0; i < b.N; i++ {
-		db, err := sql.Open("sqlite3", ":memory:")
+		db, err := d.Open(":memory:")
 		if err != nil {
-			b.Fatal(err)
-		}
-		if err := db.Ping(); err != nil {
 			b.Fatal(err)
 		}
 		if err := db.Close(); err != nil {


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/charlievieth/go-sqlite3
cpu: Apple M4 Pro
                       │   y1.txt    │               y2.txt               │
                       │   sec/op    │   sec/op     vs base               │
Suite/BenchmarkOpen-14   14.42µ ± 1%   14.08µ ± 1%  -2.41% (p=0.000 n=10)

                       │   y1.txt   │               y2.txt               │
                       │    B/op    │    B/op     vs base                │
Suite/BenchmarkOpen-14   968.0 ± 0%   712.0 ± 0%  -26.45% (p=0.000 n=10)

                       │   y1.txt   │               y2.txt               │
                       │ allocs/op  │ allocs/op   vs base                │
Suite/BenchmarkOpen-14   33.00 ± 0%   20.00 ± 0%  -39.39% (p=0.000 n=10)
```