### PR TITLE
only reset sqlite3 statement when necessary

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -31,6 +31,8 @@ jobs:
           # Handle issues with the upgrade to icu4c v76.
           [[ -e "$(brew --prefix)/opt/icu4c" ]] || \
             brew reinstall icu4c
+      - if: startsWith(matrix.os, 'ubuntu')
+        run: sudo apt install -y libsqlite3-dev
 
       - uses: actions/setup-go@v2
         with:

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -551,6 +551,7 @@ type SQLiteStmt struct {
 	s      *C.sqlite3_stmt
 	closed bool
 	cls    bool // True if the statement was created by SQLiteConn.Query
+	reset  bool // True if the statement needs to reset before re-use
 }
 
 // SQLiteResult implements sql.Result.
@@ -2197,15 +2198,20 @@ func hasNamedArgs(args []driver.NamedValue) bool {
 }
 
 func (s *SQLiteStmt) bind(args []driver.NamedValue) error {
-	rv := C.sqlite3_reset(s.s)
-	if rv != C.SQLITE_ROW && rv != C.SQLITE_OK && rv != C.SQLITE_DONE {
-		return s.c.lastError()
+	if s.reset {
+		rv := C.sqlite3_reset(s.s)
+		if rv != C.SQLITE_ROW && rv != C.SQLITE_OK && rv != C.SQLITE_DONE {
+			return s.c.lastError()
+		}
+	} else {
+		s.reset = true
 	}
 
 	if hasNamedArgs(args) {
 		return s.bindIndices(args)
 	}
 
+	var rv C.int
 	for _, arg := range args {
 		n := C.int(arg.Ordinal)
 		switch v := arg.Value.(type) {


### PR DESCRIPTION
This commit changes the bind logic to only reset the sqlite3 statement when necessary, which saves us a call to sqlite3_reset the first time the query is used.

```
goos: darwin
goarch: arm64
pkg: github.com/charlievieth/go-sqlite3
cpu: Apple M4 Pro
                              │    y1.txt    │               y2.txt               │
                              │    sec/op    │   sec/op     vs base               │
Suite/BenchmarkQuery-14          1.718µ ± 1%   1.634µ ± 0%  -4.89% (p=0.000 n=10)
Suite/BenchmarkQuerySimple-14   1009.0n ± 2%   941.1n ± 0%  -6.73% (p=0.000 n=10)
geomean                          1.317µ        1.240µ       -5.81%

                              │   y1.txt   │               y2.txt                │
                              │    B/op    │    B/op     vs base                 │
Suite/BenchmarkQuery-14         640.0 ± 0%   640.0 ± 0%       ~ (p=1.000 n=10) ¹
Suite/BenchmarkQuerySimple-14   440.0 ± 0%   440.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                         530.7        530.7       +0.00%
¹ all samples are equal

                              │   y1.txt   │               y2.txt                │
                              │ allocs/op  │ allocs/op   vs base                 │
Suite/BenchmarkQuery-14         22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=10) ¹
Suite/BenchmarkQuerySimple-14   13.00 ± 0%   13.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                         16.91        16.91       +0.00%
¹ all samples are equal
```