### PR TITLE
userauth: don't register no-op auth functions and unify public API

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -443,6 +443,7 @@ const (
 	SQLITE_OK     = C.SQLITE_OK
 	SQLITE_IGNORE = C.SQLITE_IGNORE
 	SQLITE_DENY   = C.SQLITE_DENY
+	SQLITE_AUTH   = C.SQLITE_AUTH
 
 	// different actions query tries to do - passed as argument to authorizer
 	SQLITE_CREATE_INDEX        = C.SQLITE_CREATE_INDEX
@@ -1856,7 +1857,7 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 		//
 		// If the SQLITE_USER table is not present in the database file, then
 		// this interface is a harmless no-op returnning SQLITE_OK.
-		if err := conn.RegisterFunc("authenticate", conn.authenticate, true); err != nil {
+		if err := conn.registerAuthFunc("authenticate", conn.authenticate, true); err != nil {
 			return err
 		}
 		//
@@ -1869,7 +1870,7 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 		// The AuthUserAdd only works for the "main" database, not
 		// for any ATTACH-ed databases. Any call to AuthUserAdd by a
 		// non-admin user results in an error.
-		if err := conn.RegisterFunc("auth_user_add", conn.authUserAdd, true); err != nil {
+		if err := conn.registerAuthFunc("auth_user_add", conn.authUserAdd, true); err != nil {
 			return err
 		}
 		//
@@ -1879,7 +1880,7 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 		// login credentials. Only an admin user can change another users login
 		// credentials or admin privilege setting. No user may change their own
 		// admin privilege setting.
-		if err := conn.RegisterFunc("auth_user_change", conn.authUserChange, true); err != nil {
+		if err := conn.registerAuthFunc("auth_user_change", conn.authUserChange, true); err != nil {
 			return err
 		}
 		//
@@ -1889,13 +1890,13 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 		// which guarantees that there is always an admin user and hence that
 		// the database cannot be converted into a no-authentication-required
 		// database.
-		if err := conn.RegisterFunc("auth_user_delete", conn.authUserDelete, true); err != nil {
+		if err := conn.registerAuthFunc("auth_user_delete", conn.authUserDelete, true); err != nil {
 			return err
 		}
 
 		// Register: auth_enabled
 		// auth_enabled can be used to check if user authentication is enabled
-		if err := conn.RegisterFunc("auth_enabled", conn.authEnabled, true); err != nil {
+		if err := conn.registerAuthFunc("auth_enabled", conn.authEnabled, true); err != nil {
 			return err
 		}
 

--- a/sqlite3_opt_userauth.go
+++ b/sqlite3_opt_userauth.go
@@ -65,10 +65,6 @@ import (
 	"unsafe"
 )
 
-const (
-	SQLITE_AUTH = C.SQLITE_AUTH
-)
-
 var (
 	ErrUnauthorized  = errors.New("SQLITE_AUTH: Unauthorized")
 	ErrAdminRequired = errors.New("SQLITE_AUTH: Unauthorized; Admin Privileges Required")
@@ -290,6 +286,10 @@ func (c *SQLiteConn) AuthEnabled() (exists bool) {
 //	 1 - Enabled
 func (c *SQLiteConn) authEnabled() int {
 	return int(C._sqlite3_auth_enabled(c.db))
+}
+
+func (c *SQLiteConn) registerAuthFunc(name string, impl any, pure bool) error {
+	return c.RegisterFunc(name, impl, pure)
 }
 
 // EOF

--- a/sqlite3_opt_userauth_omit.go
+++ b/sqlite3_opt_userauth_omit.go
@@ -8,8 +8,11 @@
 
 package sqlite3
 
-import (
-	"C"
+import "errors"
+
+var (
+	ErrUnauthorized  = errors.New("SQLITE_AUTH: Unauthorized")
+	ErrAdminRequired = errors.New("SQLITE_AUTH: Unauthorized; Admin Privileges Required")
 )
 
 // Authenticate will perform an authentication of the provided username
@@ -153,6 +156,11 @@ func (c *SQLiteConn) AuthEnabled() (exists bool) {
 func (c *SQLiteConn) authEnabled() int {
 	// NOOP
 	return 0
+}
+
+func (c *SQLiteConn) registerAuthFunc(_ string, _ any, _ bool) error {
+	// NOOP
+	return nil
 }
 
 // EOF


### PR DESCRIPTION
This commit changes Open to not register any of the auth functions when userauth is disabled. It also unifies the public API of this library for when userauth is enabled/disabled.

```
goos: darwin
goarch: arm64
pkg: github.com/charlievieth/go-sqlite3
cpu: Apple M4 Pro
                       │   y1.txt    │               y3.txt                │
                       │   sec/op    │   sec/op     vs base                │
Suite/BenchmarkOpen-14   13.76µ ± 1%   12.37µ ± 1%  -10.11% (p=0.000 n=10)

                       │   y1.txt   │               y3.txt               │
                       │    B/op    │    B/op     vs base                │
Suite/BenchmarkOpen-14   712.0 ± 0%   111.0 ± 1%  -84.41% (p=0.000 n=10)

                       │   y1.txt    │               y3.txt               │
                       │  allocs/op  │ allocs/op   vs base                │
Suite/BenchmarkOpen-14   20.000 ± 0%   3.000 ± 0%  -85.00% (p=0.000 n=10)
```