### PR TITLE
use extended error codes and handle closed db connections in lastError

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -36,7 +36,10 @@ func (destConn *SQLiteConn) Backup(dest string, srcConn *SQLiteConn, src string)
 		runtime.SetFinalizer(bb, (*SQLiteBackup).Finish)
 		return bb, nil
 	}
-	return nil, destConn.lastError()
+	if destConn.db != nil {
+		return nil, destConn.lastError(int(C.sqlite3_extended_errcode(destConn.db)))
+	}
+	return nil, Error{Code: 1, ExtendedCode: 1, err: "backup: destination connection is nil"}
 }
 
 // Step to backs up for one step. Calls the underlying `sqlite3_backup_step`

--- a/error.go
+++ b/error.go
@@ -13,13 +13,16 @@ package sqlite3
 #endif
 */
 import "C"
-import "syscall"
+import (
+	"sync"
+	"syscall"
+)
 
 // ErrNo inherit errno.
 type ErrNo int
 
 // ErrNoMask is mask code.
-const ErrNoMask C.int = 0xff
+const ErrNoMask = 0xff
 
 // ErrNoExtended is extended errno.
 type ErrNoExtended int
@@ -85,7 +88,7 @@ func (err Error) Error() string {
 	if err.err != "" {
 		str = err.err
 	} else {
-		str = C.GoString(C.sqlite3_errstr(C.int(err.Code)))
+		str = errorString(int(err.Code))
 	}
 	if err.SystemErrno != 0 {
 		str += ": " + err.SystemErrno.Error()
@@ -148,3 +151,22 @@ const (
 	ErrNoticeRecoverRollback  = ErrNoExtended(ErrNotice | 2<<8)
 	ErrWarningAutoIndex       = ErrNoExtended(ErrWarning | 1<<8)
 )
+
+var errStrCache sync.Map // int => string
+
+// errorString returns the result of sqlite3_errstr for result code rv,
+// which may be cached.
+func errorString(rv int) string {
+	if v, ok := errStrCache.Load(rv); ok {
+		return v.(string)
+	}
+	s := C.GoString(C.sqlite3_errstr(C.int(rv)))
+	// Prevent the cache from growing unbounded by ignoring invalid
+	// error codes.
+	if s != "unknown error" {
+		if v, loaded := errStrCache.LoadOrStore(rv, s); loaded {
+			s = v.(string)
+		}
+	}
+	return s
+}

--- a/sqlite3_opt_unlock_notify.c
+++ b/sqlite3_opt_unlock_notify.c
@@ -4,10 +4,13 @@
 // license that can be found in the LICENSE file.
 
 #ifdef SQLITE_ENABLE_UNLOCK_NOTIFY
-#include <stdio.h>
 #include "sqlite3-binding.h"
 
 extern int unlock_notify_wait(sqlite3 *db);
+
+static inline int is_locked(int rv) {
+  return rv == SQLITE_LOCKED || rv == SQLITE_LOCKED_SHAREDCACHE;
+}
 
 int
 _sqlite3_step_blocking(sqlite3_stmt *stmt)
@@ -18,10 +21,7 @@ _sqlite3_step_blocking(sqlite3_stmt *stmt)
   db = sqlite3_db_handle(stmt);
   for (;;) {
     rv = sqlite3_step(stmt);
-    if (rv != SQLITE_LOCKED) {
-      break;
-    }
-    if (sqlite3_extended_errcode(db) != SQLITE_LOCKED_SHAREDCACHE) {
+    if (!is_locked(rv)) {
       break;
     }
     rv = unlock_notify_wait(db);
@@ -43,10 +43,7 @@ _sqlite3_step_row_blocking(sqlite3_stmt* stmt, long long* rowid, long long* chan
   db = sqlite3_db_handle(stmt);
   for (;;) {
     rv = sqlite3_step(stmt);
-    if (rv!=SQLITE_LOCKED) {
-      break;
-    }
-    if (sqlite3_extended_errcode(db) != SQLITE_LOCKED_SHAREDCACHE) {
+    if (!is_locked(rv)) {
       break;
     }
     rv = unlock_notify_wait(db);
@@ -68,10 +65,7 @@ _sqlite3_prepare_v2_blocking(sqlite3 *db, const char *zSql, int nBytes, sqlite3_
 
   for (;;) {
     rv = sqlite3_prepare_v2(db, zSql, nBytes, ppStmt, pzTail);
-    if (rv!=SQLITE_LOCKED) {
-      break;
-    }
-    if (sqlite3_extended_errcode(db) != SQLITE_LOCKED_SHAREDCACHE) {
+    if (!is_locked(rv)) {
       break;
     }
     rv = unlock_notify_wait(db);

--- a/sqlite3_opt_userauth.go
+++ b/sqlite3_opt_userauth.go
@@ -91,7 +91,7 @@ func (c *SQLiteConn) Authenticate(username, password string) error {
 	case C.SQLITE_OK:
 		return nil
 	default:
-		return c.lastError()
+		return c.lastError(int(rv))
 	}
 }
 
@@ -139,7 +139,7 @@ func (c *SQLiteConn) AuthUserAdd(username, password string, admin bool) error {
 	case C.SQLITE_OK:
 		return nil
 	default:
-		return c.lastError()
+		return c.lastError(int(rv))
 	}
 }
 
@@ -189,7 +189,7 @@ func (c *SQLiteConn) AuthUserChange(username, password string, admin bool) error
 	case C.SQLITE_OK:
 		return nil
 	default:
-		return c.lastError()
+		return c.lastError(int(rv))
 	}
 }
 
@@ -237,7 +237,7 @@ func (c *SQLiteConn) AuthUserDelete(username string) error {
 	case C.SQLITE_OK:
 		return nil
 	default:
-		return c.lastError()
+		return c.lastError(int(rv))
 	}
 }
 

--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -692,7 +692,7 @@ func (c *SQLiteConn) DeclareVTab(sql string) error {
 	defer C.free(unsafe.Pointer(zSQL))
 	rv := C.sqlite3_declare_vtab(c.db, zSQL)
 	if rv != C.SQLITE_OK {
-		return c.lastError()
+		return c.lastError(int(rv))
 	}
 	return nil
 }
@@ -707,13 +707,13 @@ func (c *SQLiteConn) CreateModule(moduleName string, module Module) error {
 	case EponymousOnlyModule:
 		rv := C._sqlite3_create_module_eponymous_only(c.db, mname, C.uintptr_t(uintptr(newHandle(c, &udm))))
 		if rv != C.SQLITE_OK {
-			return c.lastError()
+			return c.lastError(int(rv))
 		}
 		return nil
 	case Module:
 		rv := C._sqlite3_create_module(c.db, mname, C.uintptr_t(uintptr(newHandle(c, &udm))))
 		if rv != C.SQLITE_OK {
-			return c.lastError()
+			return c.lastError(int(rv))
 		}
 		return nil
 	}

--- a/sqlite3_trace.go
+++ b/sqlite3_trace.go
@@ -282,7 +282,7 @@ func (c *SQLiteConn) setSQLiteTrace(sqliteEventMask uint) error {
 	// passing the database connection handle as callback context.
 
 	if rv != C.SQLITE_OK {
-		return c.lastError()
+		return c.lastError(int(rv))
 	}
 	return nil
 }


### PR DESCRIPTION
This commit changes the error handling logic so that it respects the offending result code (instead of only relying on sqlite3_errcode) and changes the db connection to always report the extended result code (which eliminates the need to call sqlite3_extended_errcode). These changes make it possible to correctly and safely handle errors when the underlying db connection has been closed.