### PR TITLE
improve performance of formatting timestamps by 35%

### DIFF
--- a/internal/timefmt/timefmt.go
+++ b/internal/timefmt/timefmt.go
@@ -1,0 +1,122 @@
+package timefmt
+
+import "time"
+
+const digits = "0123456789"
+
+const smallsString = "00010203040506070809" +
+	"10111213141516171819" +
+	"20212223242526272829" +
+	"30313233343536373839" +
+	"40414243444546474849" +
+	"50515253545556575859" +
+	"60616263646566676869" +
+	"70717273747576777879" +
+	"80818283848586878889" +
+	"90919293949596979899"
+
+func appendInt2(dst []byte, i int) []byte {
+	u := uint(i)
+	if u < 10 {
+		return append(dst, '0', digits[u])
+	}
+	return append(dst, smallsString[u*2:u*2+2]...)
+}
+
+// appendInt appends the decimal form of x to b and returns the result.
+// If the decimal form (excluding sign) is shorter than width, the result is padded with leading 0's.
+// Duplicates functionality in strconv, but avoids dependency.
+func appendInt(b []byte, x int, width int) []byte {
+	u := uint(x)
+	if x < 0 {
+		b = append(b, '-')
+		u = uint(-x)
+	}
+
+	// 2-digit and 4-digit fields are the most common in time formats.
+	utod := func(u uint) byte { return '0' + byte(u) }
+	switch {
+	case width == 2 && u < 1e2:
+		return append(b, utod(u/1e1), utod(u%1e1))
+	case width == 4 && u < 1e4:
+		return append(b, utod(u/1e3), utod(u/1e2%1e1), utod(u/1e1%1e1), utod(u%1e1))
+	}
+
+	// Compute the number of decimal digits.
+	var n int
+	if u == 0 {
+		n = 1
+	}
+	for u2 := u; u2 > 0; u2 /= 10 {
+		n++
+	}
+
+	// Add 0-padding.
+	for pad := width - n; pad > 0; pad-- {
+		b = append(b, '0')
+	}
+
+	// Ensure capacity.
+	if len(b)+n <= cap(b) {
+		b = b[:len(b)+n]
+	} else {
+		b = append(b, make([]byte, n)...)
+	}
+
+	// Assemble decimal in reverse order.
+	i := len(b) - 1
+	for u >= 10 && i > 0 {
+		q := u / 10
+		b[i] = utod(u - q*10)
+		u = q
+		i--
+	}
+	b[i] = utod(u)
+	return b
+}
+
+// formatTime formats time t with layout "2006-01-02 15:04:05.999999999-07:00"
+func Format(t time.Time) []byte {
+	b := make([]byte, 0, len("2006-01-02 15:04:05.999999999-07:00"))
+
+	// 2006-01-02
+	year, month, day := t.Date()
+	b = appendInt(b, year, 4)
+	b = append(b, '-')
+	b = appendInt2(b, int(month))
+	b = append(b, '-')
+	b = appendInt2(b, day)
+
+	// 15:04:05
+	b = append(b, ' ')
+	b = appendInt2(b, t.Hour())
+	b = append(b, ':')
+	b = appendInt2(b, t.Minute())
+	b = append(b, ':')
+	b = appendInt2(b, t.Second())
+
+	// .999999999
+	b = append(b, '.')
+	b = appendInt(b, t.Nanosecond(), 9)
+	for len(b) > 0 && b[len(b)-1] == '0' {
+		b = b[:len(b)-1]
+	}
+	if len(b) > 0 && b[len(b)-1] == '.' {
+		b = b[:len(b)-1]
+	}
+
+	// -07:00
+	_, offset := t.Zone()
+	zone := offset / 60
+	if zone < 0 {
+		b = append(b, '-')
+		zone = -zone
+	} else {
+		b = append(b, '+')
+	}
+	b = appendInt2(b, zone/60)
+	b = append(b, ':')
+	b = appendInt2(b, zone%60)
+
+	return b
+}

--- a/internal/timefmt/timefmt_test.go
+++ b/internal/timefmt/timefmt_test.go
@@ -1,0 +1,66 @@
+package timefmt_test
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/charlievieth/go-sqlite3"
+	"github.com/charlievieth/go-sqlite3/internal/timefmt"
+)
+
+func TestFormatTime(t *testing.T) {
+	// Create time locations with random offsets
+	rr := rand.New(rand.NewSource(time.Now().UnixNano()))
+	locs := make([]*time.Location, 1000)
+	for i := range locs {
+		offset := rr.Intn(60 * 60 * 14) // 14 hours
+		if rr.Int()&1 != 0 {
+			offset = -offset
+		}
+		locs[i] = time.FixedZone(strconv.Itoa(offset), offset)
+	}
+	// Append some standard locations
+	locs = append(locs, time.Local, time.UTC)
+
+	times := []time.Time{
+		{},
+		time.Now(),
+		time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+		time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC),
+		time.Date(20_000, 1, 1, 1, 1, 1, 1, time.UTC),
+		time.Date(-1, 0, 0, 0, 0, 0, 0, time.UTC),
+	}
+
+	for _, loc := range locs {
+		for _, tt := range times {
+			tt = tt.In(loc)
+			got := timefmt.Format(tt)
+			want := tt.Format(sqlite3.SQLiteTimestampFormats[0])
+			if string(got) != want {
+				t.Errorf("Format(%q) = %q; want: %q", tt.Format(time.RFC3339Nano), got, want)
+			}
+		}
+	}
+}
+
+func TestFormatTimeAllocs(t *testing.T) {
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = timefmt.Format(time.Now())
+	})
+	if allocs != 1 {
+		t.Fatalf("expected 1 allocation per-run got: %.1f", allocs)
+	}
+}
+
+func BenchmarkFormat(b *testing.B) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		b.Fatal(err)
+	}
+	ts := time.Date(2024, 1, 2, 15, 4, 5, 123456789, loc)
+	for i := 0; i < b.N; i++ {
+		_ = timefmt.Format(ts)
+	}
+}

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -404,6 +404,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"github.com/charlievieth/go-sqlite3/internal/timefmt"
 )
 
 // SQLiteTimestampFormats is timestamp formats understood by both this module
@@ -2253,9 +2255,8 @@ func (s *SQLiteStmt) bind(args []driver.NamedValue) error {
 				rv = C._sqlite3_bind_blob(s.s, n, unsafe.Pointer(&v[0]), C.int(ln))
 			}
 		case time.Time:
-			ts := v.Format(SQLiteTimestampFormats[0])
-			p := stringData(ts)
-			rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(p)), C.int(len(ts)))
+			b := timefmt.Format(v)
+			rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))
 		}
 		if rv != C.SQLITE_OK {
 			return s.c.lastError()
@@ -2322,9 +2323,8 @@ func (s *SQLiteStmt) bindIndices(args []driver.NamedValue) error {
 					rv = C._sqlite3_bind_blob(s.s, n, unsafe.Pointer(&v[0]), C.int(ln))
 				}
 			case time.Time:
-				ts := v.Format(SQLiteTimestampFormats[0])
-				p := stringData(ts)
-				rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(p)), C.int(len(ts)))
+				b := timefmt.Format(v)
+				rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))
 			}
 			if rv != C.SQLITE_OK {
 				return s.c.lastError()


### PR DESCRIPTION
Use an optimized routine for formatting timestamps in the default layout for a 35% speedup.

```
goos: darwin
goarch: arm64
pkg: github.com/charlievieth/go-sqlite3/internal/timefmt cpu: Apple M4 Pro
          │   old.txt   │               new.txt               │
          │   sec/op    │   sec/op     vs base                │
Format-14   98.27n ± 1%   63.80n ± 1%  -35.08% (p=0.000 n=10)

          │  old.txt   │            new.txt             │
          │    B/op    │    B/op     vs base            │
Format-14   48.00 ± 0%   48.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

          │  old.txt   │            new.txt             │
          │ allocs/op  │ allocs/op   vs base            │
Format-14   1.000 ± 0%   1.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```