### PR TITLE
fix handling of empty SQL queries

### DIFF
--- a/sqlite3_opt_unlock_notify.c
+++ b/sqlite3_opt_unlock_notify.c
@@ -4,7 +4,11 @@
 // license that can be found in the LICENSE file.
 
 #ifdef SQLITE_ENABLE_UNLOCK_NOTIFY
+#ifndef USE_LIBSQLITE3
 #include "sqlite3-binding.h"
+#else
+#include <sqlite3.h>
+#endif
 
 extern int unlock_notify_wait(sqlite3 *db);
 


### PR DESCRIPTION
This commit fixes the logic added by https://github.com/charlievieth/go-sqlite3/commit/1f1ff36e60ae84d4a9b164b96f3a46c0ede27b38 to correctly handle empty SQL statements.